### PR TITLE
Added debug argument for metadata factory

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -55,6 +55,7 @@
         <service id="bg_object_routing.metadata_factory" class="%bg_object_routing.metadata_factory.class%" public="false">
             <argument type="service" id="bg_object_routing.lazy_loading_driver" />
             <argument type="service" id="bg_object_routing.file_cache" />
+            <argument>%kernel.debug%</argument>
             <call method="setIncludeInterfaces">
                 <argument>true</argument>
             </call>


### PR DESCRIPTION
Just a very small addition: when the kernel is in debug mode (e.g. in the dev environment) this will make sure that the metadata will be parsed again, when the file containing the annotations has changed.
