### PR TITLE
object-routing released 1.0 recently

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "dev",
     "require": {
         "symfony/framework-bundle": "~2.1",
-        "jms/object-routing": "dev-master"
+        "jms/object-routing": "~1.0"
     },
     "autoload": {
         "psr-0": { "BG\\ObjectRoutingBundle": "" }


### PR DESCRIPTION
See https://github.com/schmittjoh/object-routing/releases. So, use a stable version in `composer.json`.

Additionally, could you please release a 1.0 after this change as well?

The code seems to be fairly stable here :-), so I think a stable version that would simplify composer installs would be great.

🍻 