### PR TITLE
Remove classname parameters

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,57 +4,45 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-        <parameter key="bg_object_routing.adapter.symfony_22.class">JMS\ObjectRouting\Symfony\Symfony22Adapter</parameter>
-        <parameter key="bg_object_routing.object_router.class">JMS\ObjectRouting\ObjectRouter</parameter>
-        <parameter key="bg_object_routing.twig_extension.class">JMS\ObjectRouting\Twig\RoutingExtension</parameter>
-
-        <parameter key="bg_object_routing.metadata_factory.class">Metadata\MetadataFactory</parameter>
-        <parameter key="bg_object_routing.lazy_loading_driver.class">Metadata\Driver\LazyLoadingDriver</parameter>
-        <parameter key="bg_object_routing.driver_chain.class">Metadata\Driver\DriverChain</parameter>
-        <parameter key="bg_object_routing.annotation_driver.class">JMS\ObjectRouting\Metadata\Driver\AnnotationDriver</parameter>
-        <parameter key="bg_object_routing.file_cache.class">Metadata\Cache\FileCache</parameter>
-    </parameters>
-
     <services>
-        <service id="bg_object_routing.adapter.symfony_22" class="%bg_object_routing.adapter.symfony_22.class%" public="false">
+        <service id="bg_object_routing.adapter.symfony_22" class="JMS\ObjectRouting\Symfony\Symfony22Adapter" public="false">
             <argument type="service" id="router" />
         </service>
 
         <service id="bg_object_routing.adapter" alias="bg_object_routing.adapter.symfony_22" public="false"/>
 
-        <service id="bg_object_routing.object_router" class="%bg_object_routing.object_router.class%">
+        <service id="bg_object_routing.object_router" class="JMS\ObjectRouting\ObjectRouter">
             <argument type="service" id="bg_object_routing.adapter" />
             <argument type="service" id="bg_object_routing.metadata_factory" />
         </service>
 
-        <service id="bg_object_routing.twig_extension" class="%bg_object_routing.twig_extension.class%">
+        <service id="bg_object_routing.twig_extension" class="JMS\ObjectRouting\Twig\RoutingExtension">
             <argument type="service" id="bg_object_routing.object_router" />
             <tag name="twig.extension"/>
         </service>
 
-        <service id="bg_object_routing.driver_chain" class="%bg_object_routing.driver_chain.class%" public="false">
+        <service id="bg_object_routing.driver_chain" class="Metadata\Driver\DriverChain" public="false">
             <argument type="collection">
                 <argument type="service" id="bg_object_routing.annotation_driver" />
             </argument>
         </service>
         <service id="bg_object_routing.metadata_driver" alias="bg_object_routing.driver_chain"></service>
 
-        <service id="bg_object_routing.lazy_loading_driver" class="%bg_object_routing.lazy_loading_driver.class%" public="false">
+        <service id="bg_object_routing.lazy_loading_driver" class="Metadata\Driver\LazyLoadingDriver" public="false">
             <argument type="service" id="service_container" />
             <argument>bg_object_routing.metadata_driver</argument>
         </service>
 
-        <service id="bg_object_routing.annotation_driver" class="%bg_object_routing.annotation_driver.class%" public="false">
+        <service id="bg_object_routing.annotation_driver" class="JMS\ObjectRouting\Metadata\Driver\AnnotationDriver" public="false">
             <argument type="service" id="annotation_reader" />
         </service>
 
-        <service id="bg_object_routing.file_cache" class="%bg_object_routing.file_cache.class%" public="false">
+        <service id="bg_object_routing.file_cache" class="Metadata\Cache\FileCache" public="false">
             <argument>%bg_object_routing.cache_dir%</argument>
             <argument>%kernel.debug%</argument>
         </service>
 
-        <service id="bg_object_routing.metadata_factory" class="%bg_object_routing.metadata_factory.class%" public="false">
+        <service id="bg_object_routing.metadata_factory" class="Metadata\MetadataFactory" public="false">
             <argument type="service" id="bg_object_routing.lazy_loading_driver" />
             <argument type="service" id="bg_object_routing.file_cache" />
             <argument>%kernel.debug%</argument>


### PR DESCRIPTION
This is a discouraged practice in Symfony, at least since version 3.0.