### PR TITLE
Allow symfony/framework-bundle versions 3.x or 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "^2.2",
+        "symfony/framework-bundle": "^2.2|^3.0|^4.0",
         "jms/object-routing": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
To be honest, I haven't actually checked this bundle with those versions yet. But as there is so little in it, I don't see why it should not work.